### PR TITLE
More settings, but with flattened storage schema

### DIFF
--- a/src/content/jobr-plus.js
+++ b/src/content/jobr-plus.js
@@ -19,29 +19,20 @@ const defaultSettings = {
 		'443': 'BackEnd',
 		'407': 'ProjMgmt'
 	},
-	defaultDuration: '.5',
-	defaultTask: '443'
+	defaultDuration: '',
+	defaultTask: ''
 };
 
 let settings;
 let useDefaultTask = true;
 
 async function initSettings() {
-	browser.storage.onChanged.addListener( ( changes, areaName ) => {
-		if ( areaName === 'sync' && !!changes['settings'] )
-		{
-			console.log( 'j-p.js: settings changed', changes );
-			settings = changes['settings'].newValue || [];
-			updateShortcutButtons();
-		}
-	} );
-
-	const results = await browser.storage.sync.get( 'settings' );
-	settings = results?.settings ?? defaultSettings;
-	if ( !results?.settings )
-	{
+	settings = await browser.storage.sync.get(null);
+	
+	if ( !settings || Object.keys(settings).length == 0 ) {
 		console.log( 'setting default settings' );
-		browser.storage.sync.set( { settings } );
+		settings = {...defaultSettings};
+		browser.storage.sync.set( {...defaultSettings} );
 	}
 
 	console.log( settings );
@@ -49,6 +40,14 @@ async function initSettings() {
 }
 
 initSettings();
+
+browser.storage.onChanged.addListener( ( changes, areaName ) => {
+	console.log({areaName});
+	if ( areaName === 'sync' ) {
+		console.log( 'j-p.js: settings changed', changes );
+		initSettings();
+	}
+} );
 
 function updateShortcutButtons() {
 	if ( !isShowingJobs ) return;

--- a/src/content/jobr-plus.js
+++ b/src/content/jobr-plus.js
@@ -179,11 +179,11 @@ jQuery( function ( $ ) {
 	// Auto-login
 	setTimeout( function () {
 		const login_button = $( '#gobutton' );
-		if ( login_button && settings.login.u && settings.login.p )
+		if ( login_button && settings?.login?.u && settings?.login?.p )
 		{
 			login_button.hide();
-			$( "#initials" ).val( settings.login.u );
-			$( "#paswd" ).val( settings.login.p );
+			$( "#initials" ).val( settings?.login?.u );
+			$( "#paswd" ).val( settings?.login?.p );
 		}
 		if ( login_button && $( "#initials" ).val() && $( "#paswd" ).val() )
 		{

--- a/src/popup/App.svelte
+++ b/src/popup/App.svelte
@@ -13,7 +13,7 @@
             return false;
         }
 
-        browser.storage.sync.set({settings: settingsParsed});
+        browser.storage.sync.set(settingsParsed);
         window.close();
     }
 
@@ -30,18 +30,17 @@
         settingsParsed = undefined;
         isValid = false;
     }
+    
+    async function loadSettings() {
+        console.log('getting settings');
+        settingsSaved = await browser.storage.sync.get(null)
+        settingsJson = JSON.stringify(settingsSaved, null, 2);
+    }
+    
+    loadSettings();
 
-    browser.storage.sync.get('settings').then(({settings}) => {
-        settingsSaved = settings ?? {};
-        settingsJson = JSON.stringify(settings, null, 2);
-    });
-
-    browser.storage.onChanged.addListener((changes, areaName) => {
-        if (areaName === 'sync' && typeof changes['settings'] !== 'undefined') {
-            console.log('a.sv: settings changed', changes);
-            settingsSaved = changes['settings'].newValue;
-            settingsJson = JSON.stringify(settingsSaved, null, 2);
-        }
+    browser.storage.onChanged.addListener((_changes, areaName) => {
+        if (areaName === 'sync') loadSettings();
     });
 </script>
 


### PR DESCRIPTION
I think I've achieved parity with the feature/add-more-settings branch without needing an extra layer in the settings data structure.